### PR TITLE
Add support for fitting bayesian models with brms

### DIFF
--- a/lulcc/R/models.R
+++ b/lulcc/R/models.R
@@ -98,6 +98,30 @@ rpartModels <- function(formula, ..., obs, categories=NA, labels=NA) {
                labels=labels)
 }
 
+brmModels <- function(formula, 
+                      family=binomial,
+                      obs, categories=NA, labels=NA,
+                      ...) {
+  
+  brm.models <- list()
+  
+  if (!missing(obs)) {
+    categories <- obs@categories
+    labels <- obs@labels
+  }
+  
+  formula <- .checkFormula(formula, categories, labels)
+  
+  for (i in 1:length(formula)) {
+    form <- formula[[i]]
+    brm.models[[i]] <- brms::brm(form, family = family, ...)
+  }
+  
+  out <- new("PredictiveModelList",
+             models=brm.models,
+             categories=categories,
+             labels=labels)
+}
 
 .checkFormula <- function(formula, categories, labels) {
     dep <- sapply(formula, function(x) as.character(x)[2])

--- a/lulcc/R/predict.R
+++ b/lulcc/R/predict.R
@@ -81,6 +81,9 @@ predict.PredictiveModelList <- function(object, newdata, data.frame=FALSE, ...) 
             out[[i]] <- predict(object=mod, newdata=newdata, type="response")#, ...)
         }
         ## out[[i]] <- predict(object=object@models[[i]], newdata=newdata, ...)
+        if (inherits(mod, "brmsfit")) {
+            out[[i]] <- predict(object=mod, newdata=newdata)#, ...)
+        }
     }
 
     names(out) <- object@labels


### PR DESCRIPTION
This adds a new methods called `brmModels` similar to `glmModels` to add support for `brms` models.
From my own testing, this works well and the usual workflow can be used. Usual diagnostics of the fitted models can still be done with the tools included in `brms`.

I do not have the knowledge necessary to update documentation and formatting of source files for a CRAN version.