### PR TITLE
Fix timestep inputs

### DIFF
--- a/lulcc/R/as.data.frame.R
+++ b/lulcc/R/as.data.frame.R
@@ -78,6 +78,7 @@ as.data.frame.ObsLulcRasterStack <- function(x, row.names=NULL, optional=FALSE, 
     
     if (!t %in% x@t) {
         warning("Invalid t: no land use map for this time. Using setting t = 0 instead.")
+        warning(paste("Valid timesteps are:", paste0(x@t, collapse = ", ")))
         t <- 0
     }
     

--- a/lulcc/R/as.data.frame.R
+++ b/lulcc/R/as.data.frame.R
@@ -56,10 +56,10 @@ NULL
 #' @rdname as.data.frame
 #' @method as.data.frame ExpVarRasterList
 #' @export
-as.data.frame.ExpVarRasterList <- function(x, row.names=NULL, optional=FALSE, cells, t=0, ...) {
-    ix <- t + 1
+as.data.frame.ExpVarRasterList <- function(x, row.names=NULL, optional=FALSE, cells, obs, t=0, ...) {
+    
     ##maps <- c(.getExpVarRasterList(x@maps, t), lapply(x@calls, function(x) x@map))
-    maps <- .getExpVarRasterList(x@maps, t)
+    maps <- .getExpVarRasterList(x@maps, t, obs)
     df <- as.data.frame(matrix(data=NA, nrow=length(cells), ncol=length(maps)))
     for (i in 1:length(maps)) {
         df[,i] <- extract(maps[[i]], cells, ...)
@@ -75,20 +75,20 @@ as.data.frame.ExpVarRasterList <- function(x, row.names=NULL, optional=FALSE, ce
 #' @method as.data.frame ObsLulcRasterStack
 #' @export
 as.data.frame.ObsLulcRasterStack <- function(x, row.names=NULL, optional=FALSE, cells, t=0, ...) {
-
+    
     if (!t %in% x@t) {
-        print("no observed map at time 't': using setting t = 0 instead")
+        warning("Invalid t: no land use map for this time. Using setting t = 0 instead.")
         t <- 0
     }
-
+    
     ix <- which(x@t %in% t)
-
+    
     br <- raster::layerize(x[[ix]])
     names(br) <- x@labels
     df <- as.data.frame(raster::extract(x=br, y=cells))
     df
 }
-    
+
 
 #' @rdname as.data.frame
 #' @aliases as.data.frame,ExpVarRasterList-method
@@ -123,22 +123,23 @@ setMethod("as.data.frame","ObsLulcRasterStack",as.data.frame.ObsLulcRasterStack)
             x[,dynamic.ix] <- update.vals
         }
     }
-
+    
     names(x) <- nms
     x
 }
-    
-.getExpVarRasterList <- function(maps, t) {
-    index <- t + 1
+
+.getExpVarRasterList <- function(maps, t, obs) {
+    index <- which(t == obs@t)
     for (i in 1:length(maps)) {
         s <- maps[[i]]
         n <- raster::nlayers(s)
         if (n == 1) {
             maps[[i]] <- s[[1]]
-        } else if (index <= n) {
+        } else if (length(index) == 1) {
             maps[[i]] <- s[[index]] 
-        } else if (index > n) {
-            stop("invalid t: dynamic explanatory variables, but no data for this time")
+        } else {
+            warning("Invalid t: dynamic variables present, but no data for this time. Using setting t = 0 instead.")
+            maps[[i]] <- s[[1]]
         }
     }
     maps

--- a/lulcc/R/getPredictiveModelInputData.R
+++ b/lulcc/R/getPredictiveModelInputData.R
@@ -27,7 +27,7 @@ NULL
 
 getPredictiveModelInputData <- function(obs, ef, cells, ...) {
     obsdf <- as.data.frame(obs, cells=cells, ...)
-    efdf  <- as.data.frame(ef, cells=cells, ...)
+    efdf  <- as.data.frame(ef, cells=cells, obs=obs, ...)
     df    <- cbind(obsdf, efdf)
     df
 }


### PR DESCRIPTION
This provides a fix for issue #1 by implementing the following features: 
- the user can define the timesteps `t` they wish when constructing a `ObsLulcRasterStack` object and when getting inputs  with `getPredictiveModelInputData`
- if the `t` entered in `getPredictiveModelInputData` doesn't match any of the `t` values in `ObsLulcRasterStack@t` then all outputs are defaulted to `t=0`
- if one of the dynamic variable is not available for a given timestep (i.e there 3 land use maps but dynamic variables are only available for timestep 1 and 2 for instance) the output for this defaults to the highest timestep available.

I have tested this with the follwing script: 

```r
library(lulcc)

lu1 = raster(matrix(sample(5:6, 100, replace=T), 10, 10))
lu2 = raster(matrix(sample(5:6, 100, replace=T), 10, 10))
lu3 = raster(matrix(sample(5:6, 100, replace=T), 10, 10))

stackoflu = stack(lu1,lu2,lu3)

va1.1 = raster(matrix(sample(1:2, 100, replace=T), 10, 10))
va1.2 = raster(matrix(sample(10:20, 100, replace=T), 10, 10))
va2 = raster(matrix(sample(3:4, 100, replace=T), 10, 10))

stackofvar = stack(va1.1,va1.2, va2)
names(stackofvar) = c("di_01_000", "di_01_001", "cli_02")

lustack = ObsLulcRasterStack(x = stackoflu,
                             categories = c(5,6), 
                             labels = c("Built", "Cropland"),
                             t = c(0,6,12)) 

varstack = ExpVarRasterList(stackofvar)

part = partition(x = lustack[[1]], size = 0.1, spatial = TRUE)
train = getPredictiveModelInputData(obs=lustack, 
                                    ef=varstack, 
                                    cells=part[["train"]],
                                    t=0) # modify this value for testing purposes, with cases t=0,1,6,12,13
train
```